### PR TITLE
Let audio access socket file in /ipc/config

### DIFF
--- a/primary/audio_hw.c
+++ b/primary/audio_hw.c
@@ -57,8 +57,8 @@
 #define PCM_DEVICE 0
 
 #ifdef USE_PULSE_SOCKET
-#define CIC_SOCKET_OUT "/data/misc/audio/cic_pulseaudio_out.socket"
-#define CIC_SOCKET_IN "/data/misc/audio/cic_pulseaudio_in.socket"
+#define CIC_SOCKET_OUT "/ipc/config/audio/cic_pulseaudio_out.socket"
+#define CIC_SOCKET_IN "/ipc/config/audio/cic_pulseaudio_in.socket"
 #endif
 
 #define OUT_PERIOD_SIZE 4800


### PR DESCRIPTION
With FBE enabled, the audio socket file cannot map to
/data/misc/audio anylonger. Let audio access the socket
file in /ipc/config directly.

Tracked-On: OAM-91124
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>