### PR TITLE
HDMI audio dynamic routing

### DIFF
--- a/hdmi/tinyaudio_hw.c
+++ b/hdmi/tinyaudio_hw.c
@@ -54,6 +54,7 @@
 #include <stdint.h>
 #include <sys/time.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <cutils/log.h>
 #include <cutils/str_parms.h>
@@ -72,6 +73,8 @@
 
 #define DEFAULT_DEVICE             3
 #define DEFAULT_DEVICE_EHL         7
+
+#define MAX_HDMI_DEVICES         20
 
 /*this is used to avoid starvation*/
 #define LATENCY_TO_BUFFER_SIZE_RATIO 2
@@ -111,6 +114,7 @@ struct pcm_config pcm_config_default = {
     .period_count = 4,
     .format = PCM_FORMAT_S16_LE,
 };
+static int parse_hdmi_device_number();
 
 #define CHANNEL_MASK_MAX 3
 struct audio_device {
@@ -228,25 +232,25 @@ static int start_output_stream(struct stream_out *out)
     struct audio_device *adev = out->dev;
     struct pcm_params *params;
     int device = 0;
-
     ALOGV("%s enter",__func__);
-
-    if ((adev->card < 0) || (adev->device < 0)){
+    if ((adev->card < 0) || (adev->device < 0)) {
         char value[PROPERTY_VALUE_MAX];
-
+ 
         /*this will be updated once the hot plug intent
           sends these information.*/
-        adev->card = DEFAULT_CARD;
+        adev->card = DEFAULT_CARD; 
+        adev->device = parse_hdmi_device_number();
+        if (adev->device < 0) {
+            ALOGE ("%s : Error while parsing the mixer controls, assigning the default device", __func__);
+            adev->device = DEFAULT_DEVICE;
+        }
+        /*Keeping the condition check only for EHL, as it is not verified*/
         property_get("ro.vendor.hdmi.audio", value, "0");
         if (!strcmp(value,"ehl")) {
             adev->device = DEFAULT_DEVICE_EHL;
-        } else {
-            adev->device = DEFAULT_DEVICE;
+            ALOGV ("%s : Setting default card/ device %d,%d", __func__, adev->card, adev->device);
         }
-
-        ALOGV("%s : Setting default card/ device %d,%d",__func__,adev->card,adev->device);
     }
-
     ALOGV("%s enter %d,%d,%d,%d,%d",__func__,
           out->pcm_config.channels,
           out->pcm_config.rate,
@@ -419,7 +423,52 @@ static int out_set_parameters(struct audio_stream *stream, const char *kvpairs)
     ALOGV("%s exit",__func__);
     return 0;
 }
+static int parse_hdmi_device_number()
+{
+    struct mixer *mixer;
+    int card = 0;
+    struct mixer_ctl *ctl;
+    enum mixer_ctl_type mixer_type;
+    unsigned int num_values;
+    unsigned int i,id,j;
+    bool device_status;
 
+    ALOGV("%s enter",__func__);
+    card = get_card_number_by_name("PCH"); 
+    mixer = mixer_open(card);
+    if (!mixer) {
+        ALOGE(" Failed to open mixer\n");
+        return -1;
+    }
+    for (i = 0; i < MAX_HDMI_DEVICES; i++) {
+       char ctl_name[100] ;
+       enum mixer_ctl_type type;
+       unsigned int num_values;
+       snprintf(ctl_name, sizeof(ctl_name), "HDMI/DP,pcm=%d Jack", i);
+       ctl = mixer_get_ctl_by_name(mixer, ctl_name);
+       if (ctl) {
+           type = mixer_ctl_get_type(ctl);
+           num_values = mixer_ctl_get_num_values(ctl);  
+           for (j = 0; j < num_values; j++) {
+               switch (type) {
+                   case MIXER_CTL_TYPE_BOOL:
+                   ALOGV("mixer_ctl_get_value %s", mixer_ctl_get_value(ctl, j) ? "On" : "Off");
+                   if (mixer_ctl_get_value(ctl, j)) {
+                       ALOGV(" status of device %d is ON", i);
+                       ALOGV("%s exit", __func__);
+                       return i;
+                   }
+                   break;
+
+                   default:
+                   break;
+               }
+           }   
+       }
+    }
+    ALOGV("%s exit",__func__);
+    return DEFAULT_DEVICE;
+}
 static int parse_channel_map()
 {
     struct mixer *mixer;
@@ -921,7 +970,6 @@ static void adev_close_input_stream(struct audio_hw_device *dev,
     UNUSED_PARAMETER(dev);
     UNUSED_PARAMETER(stream);
 }
-
 static int adev_dump(const audio_hw_device_t *device, int fd)
 {
     UNUSED_PARAMETER(device);


### PR DESCRIPTION
To get the HDMI audio device and route
to the ON device

Tracked-On: OAM-98195
Signed-off-by: Deepa G K <g.k.deepa@intel.com>