### PR TITLE
Remove -fno-strict-overflow to fix Android T build errors

### DIFF
--- a/hdmi/Android.mk
+++ b/hdmi/Android.mk
@@ -36,7 +36,6 @@ LOCAL_C_INCLUDES += \
     external/tinyalsa/include
 
 LOCAL_CFLAGS :=\
- -fno-strict-overflow \
  -fwrapv \
  -D_FORTIFY_SOURCE=2 \
  -fstack-protector-strong \

--- a/primary/Android.mk
+++ b/primary/Android.mk
@@ -37,7 +37,6 @@ LOCAL_C_INCLUDES += \
 	$(call include-path-for, audio-effects)
 
 LOCAL_CFLAGS :=\
- -fno-strict-overflow \
  -fwrapv \
  -D_FORTIFY_SOURCE=2 \
  -fstack-protector-strong \

--- a/usb/Android.mk
+++ b/usb/Android.mk
@@ -37,7 +37,6 @@ LOCAL_C_INCLUDES += \
 	$(call include-path-for, audio-effects)
 
 LOCAL_CFLAGS :=\
- -fno-strict-overflow \
  -fwrapv \
  -D_FORTIFY_SOURCE=2 \
  -fstack-protector-strong \


### PR DESCRIPTION
This is a WA patch to fix below build error in
Android T:
clang: error: argument unused during compilation:
 '-fno-strict-overflow' [-Werror,-Wunused-command-line-argument]

Tracked-On: OAM-103588
Signed-off-by: svenate <salini.venate@intel.com>