### PR TITLE
Enable dynamic detection of sound card

### DIFF
--- a/primary/audio_hw.c
+++ b/primary/audio_hw.c
@@ -46,6 +46,10 @@
 #include <audio_utils/resampler.h>
 #include <audio_route/audio_route.h>
 
+#define GET_PCM_CARD_NUMBER(temp_card)  ((temp_card = get_pcm_card("PCH")!=-1? temp_card:\
+    (temp_card = get_pcm_card("Intel")!=-1? temp_card:\
+    temp_card = get_pcm_card("sofhdadsp"))))
+
 #define PCM_CARD 0
 #define PCM_CARD_DEFAULT 0
 #define PCM_DEVICE 0
@@ -251,13 +255,13 @@ static int get_pcm_card(const char* name)
 
         written = readlink(id_filepath, number_filepath, sizeof(number_filepath));
         if (written < 0) {
-            ALOGE("Sound card %s does not exist - setting default", name);
-                return 0;
+            ALOGE("Sound card %s does not exist\n", name);
+            return -1;
         } else if (written >= (ssize_t)sizeof(id_filepath)) {
-            ALOGE("Sound card %s name is too long - setting default", name);
-            return 0;
+            ALOGE("Sound card %s name is too long - setting default \n", name);
+            return -1;
         }
-
+        ALOGI("Sound card %s exists\n", name);
         return atoi(number_filepath + 4);
 }
 
@@ -1063,16 +1067,14 @@ static int adev_open_output_stream(struct audio_hw_device *dev,
     struct pcm_params *params;
 
     int ret;
+    int temp_card = 0;
 
-    params = pcm_params_get(PCM_CARD_DEFAULT, PCM_DEVICE, PCM_OUT);
-
-    if(params != NULL) {
-       adev->card = PCM_CARD_DEFAULT;
-    } else {
+    adev->card = GET_PCM_CARD_NUMBER(temp_card);
+    params = pcm_params_get(adev->card, PCM_DEVICE, PCM_OUT);
+    if (params == NULL) {
         adev->card = get_pcm_card("Dummy");
         params = pcm_params_get(adev->card, PCM_DEVICE, PCM_OUT);
     }
-
     ALOGI("PCM playback card selected = %d, \n", adev->card);
 
     if (!params)
@@ -1326,17 +1328,15 @@ static int adev_open_input_stream(struct audio_hw_device *dev,
     struct pcm_params *params;
 
     *stream_in = NULL;
+    int temp_card = 0;
 
-    params = pcm_params_get(PCM_CARD_DEFAULT, PCM_DEVICE, PCM_IN);
-
-    if(params != NULL) {
-        adev->cardc = PCM_CARD_DEFAULT;
-    } else {
+    adev->cardc = GET_PCM_CARD_NUMBER(temp_card);
+    params = pcm_params_get(adev->cardc, PCM_DEVICE, PCM_IN);
+    if (params == NULL) {
         adev->cardc = get_pcm_card("Dummy");
         params = pcm_params_get(adev->cardc, PCM_DEVICE, PCM_IN);
     }
-
-    ALOGI("PCM capture card selected = %d, \n", adev->card);
+    ALOGI("PCM capture card selected = %d, \n", adev->cardc);
 
     in = (struct stream_in *)calloc(1, sizeof(struct stream_in));
     if (!in) {
@@ -1445,7 +1445,7 @@ static int adev_open(const hw_module_t* module, const char* name,
     ALOGV("adev_open: %s", name);
 
     struct audio_device *adev;
-    int card = 0;
+    int card, temp_card = 0;
     char mixer_path[PATH_MAX];
 
     if (strcmp(name, AUDIO_HARDWARE_INTERFACE) != 0)
@@ -1477,8 +1477,9 @@ static int adev_open(const hw_module_t* module, const char* name,
     adev->hw_device.close_input_stream = adev_close_input_stream;
     adev->hw_device.dump = adev_dump;
     adev->hw_device.get_microphones = adev_get_microphones;
-
-    snprintf(mixer_path,PATH_MAX,"/vendor/etc/mixer_paths_%d.xml", card);
+ 
+    card = GET_PCM_CARD_NUMBER(temp_card);
+    snprintf(mixer_path,PATH_MAX,"/vendor/etc/mixer_paths_0.xml");
     adev->ar = audio_route_init(card, mixer_path);
     if (!adev->ar) {
         ALOGE("%s: Failed to init audio route controls for card %d, aborting.",


### PR DESCRIPTION
This patch adds logic to detect sound card dynamically, instead of having hardcoded deafult sound card as zero.

Tracked-On:
Signed-off-by: pmandri <padmashree.mandri@intel.com>